### PR TITLE
fix: typo in property name for props types

### DIFF
--- a/src/Head.jsx
+++ b/src/Head.jsx
@@ -11,7 +11,7 @@ const Head = ({ children, sorting, ...headProps }) => { // eslint-disable-line
     );
 };
 
-Head.PropTypes = {
+Head.propTypes = {
     children: ReactPropTypes.node,
     sorting: PropTypes.sorting
 };


### PR DESCRIPTION
Fixing small typo in the name of a property for propTypes. React is rising warnings in console.

Error in console:
![image](https://user-images.githubusercontent.com/532511/43268401-d7983710-90f0-11e8-818f-6e2246a8501d.png)

Doc:
https://reactjs.org/docs/typechecking-with-proptypes.html